### PR TITLE
Adding increased timeouts due to RDS failures on deployment

### DIFF
--- a/groups/xml-infrastructure/rds.tf
+++ b/groups/xml-infrastructure/rds.tf
@@ -93,6 +93,12 @@ module "xml_rds" {
     },
   ]
 
+  timeouts = {
+    "create" : "80m",
+    "delete" : "80m",
+    "update" : "80m"
+  }
+
   tags = merge(
     local.default_tags,
     map(


### PR DESCRIPTION
Default module timeouts not allowing build to finish so have increased within the code.