### PR TITLE
Converting cloudwatch log exports to a variable

### DIFF
--- a/groups/xml-infrastructure/profiles/heritage-development-eu-west-2/vars
+++ b/groups/xml-infrastructure/profiles/heritage-development-eu-west-2/vars
@@ -23,6 +23,14 @@ major_engine_version = "12.1"
 engine_version       = "12.1.0.2.v22"
 license_model        = "license-included"
 
+# RDS logging
+rds_log_exports = [
+    "alert",
+    "audit",
+    "listener",
+    "trace"
+]
+
 # RDS Access
 rds_onpremise_access = [
   "192.168.90.0/24"

--- a/groups/xml-infrastructure/rds.tf
+++ b/groups/xml-infrastructure/rds.tf
@@ -58,14 +58,9 @@ module "xml_rds" {
   final_snapshot_identifier = "${var.application}-final-deletion-snapshot"
 
   # Enhanced Monitoring
-  monitoring_interval = "30"
-  monitoring_role_arn = data.aws_iam_role.rds_enhanced_monitoring.arn
-  enabled_cloudwatch_logs_exports = [
-    "alert",
-    "audit",
-    "listener",
-    "trace"
-  ]
+  monitoring_interval             = "30"
+  monitoring_role_arn             = data.aws_iam_role.rds_enhanced_monitoring.arn
+  enabled_cloudwatch_logs_exports = var.rds_log_exports
 
   # RDS Security Group
   vpc_security_group_ids = [

--- a/groups/xml-infrastructure/variables.tf
+++ b/groups/xml-infrastructure/variables.tf
@@ -85,6 +85,12 @@ variable "rds_onpremise_access" {
   default     = []
 }
 
+variable "rds_log_exports" {
+  type        = list(string)
+  description = "A list log types to export from RDS to Cloudwatch"
+  default     = []
+}
+
 # ------------------------------------------------------------------------------
 # RDS Engine Type Variables
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
Converting cloudwatch log exports to a variable so it can be controlled per environment, defaults to none