### PR TITLE
Pinning RDS to specific version to ensure no deployments without prior knowledge

### DIFF
--- a/groups/xml-infrastructure/rds.tf
+++ b/groups/xml-infrastructure/rds.tf
@@ -51,7 +51,7 @@ module "xml_rds_security_group" {
 # ------------------------------------------------------------------------------
 module "xml_rds" {
   source  = "terraform-aws-modules/rds/aws"
-  version = "~> 2.0"
+  version = "2.23.0"
 
   create_db_parameter_group = "true"
   create_db_subnet_group    = "true"

--- a/groups/xml-infrastructure/rds.tf
+++ b/groups/xml-infrastructure/rds.tf
@@ -51,7 +51,7 @@ module "xml_rds_security_group" {
 # ------------------------------------------------------------------------------
 module "xml_rds" {
   source  = "terraform-aws-modules/rds/aws"
-  version = "2.23.0"
+  version = "2.23.0" # Pinned version to ensure updates are a choice, can be upgraded if new features are available and required.
 
   create_db_parameter_group = "true"
   create_db_subnet_group    = "true"


### PR DESCRIPTION
Pinning RDS to specific version to ensure no deployments without prior knowledge