### PR TITLE
add source cron from fess github repo template

### DIFF
--- a/groups/xml-infrastructure/templates/bep_cron.tpl
+++ b/groups/xml-infrastructure/templates/bep_cron.tpl
@@ -1,3 +1,6 @@
+############ 1 ############ LOAD CRON FROM TEMPLATE
+#*/1 * * * * ${HOME}/supportscripts/load_cron.sh >> ${HOME}/load_cron.log
+
 #LIVE#########################LIVE SERVICE PROCESSING START########################
 #LIVE#########################Form Partition#######################################
 #LIVE# Monday to Tuesday


### PR DESCRIPTION
add source cron from fess github repo template.

Linked to `load_cron` of 
https://github.com/companieshouse/chl-perl/pull/4223/files