### PR TITLE
decrease autoscaling default size to 1

### DIFF
--- a/groups/xml-infrastructure/profiles/heritage-staging-eu-west-2/vars
+++ b/groups/xml-infrastructure/profiles/heritage-staging-eu-west-2/vars
@@ -14,7 +14,7 @@ environment = "staging"
 # Frontend ASG settings
 fe_instance_size = "t2.large"
 fe_min_size = 1
-fe_max_size = 1
+fe_max_size = 6
 fe_desired_capacity = 1
 
 # FE Load Balancer

--- a/groups/xml-infrastructure/profiles/heritage-staging-eu-west-2/vars
+++ b/groups/xml-infrastructure/profiles/heritage-staging-eu-west-2/vars
@@ -13,9 +13,9 @@ environment = "staging"
 
 # Frontend ASG settings
 fe_instance_size = "t2.large"
-fe_min_size = 6
-fe_max_size = 6
-fe_desired_capacity = 6
+fe_min_size = 1
+fe_max_size = 1
+fe_desired_capacity = 1
 
 # FE Load Balancer
 public_allow_cidr_blocks = [


### PR DESCRIPTION
We can scale up when required, but by default it should be 1 FE,
which is even an easier configuration when it's required to start debugging.