### PR TITLE
Add RDS Start/Stop Schedules

### DIFF
--- a/groups/xml-infrastructure/profiles/heritage-development-eu-west-2/vars
+++ b/groups/xml-infrastructure/profiles/heritage-development-eu-west-2/vars
@@ -313,3 +313,7 @@ bep_cw_logs = {
     log_group_retention = 7
   }
 }
+
+rds_schedule_enable = true
+rds_start_schedule = "cron(0 5 * * ? *)"
+rds_stop_schedule = "cron(0 21 * * ? *)"

--- a/groups/xml-infrastructure/profiles/heritage-staging-eu-west-2/vars
+++ b/groups/xml-infrastructure/profiles/heritage-staging-eu-west-2/vars
@@ -333,3 +333,7 @@ bep_cw_logs = {
     log_group_retention = 7
   }
 }
+
+rds_schedule_enable = true
+rds_start_schedule = "cron(0 5 * * ? *)"
+rds_stop_schedule = "cron(0 21 * * ? *)"

--- a/groups/xml-infrastructure/rds.tf
+++ b/groups/xml-infrastructure/rds.tf
@@ -141,3 +141,13 @@ module "xml_rds" {
     )
   )
 }
+
+module "rds_start_stop_schedule" {
+  source = "git@github.com:companieshouse/terraform-modules//aws/rds_start_stop_schedule?ref=tags/1.0.131"
+
+  rds_schedule_enable = var.rds_schedule_enable
+
+  rds_instance_id     = module.xml_rds.this_db_instance_id
+  rds_start_schedule  = var.rds_start_schedule
+  rds_stop_schedule   = var.rds_stop_schedule
+}

--- a/groups/xml-infrastructure/variables.tf
+++ b/groups/xml-infrastructure/variables.tf
@@ -168,6 +168,24 @@ variable "rds_backup_window" {
   description = "A backup window that allows AWS to backup your RDS instance e.g. `03:00-06:00`"
 }
 
+variable "rds_schedule_enable" {
+  type        = bool
+  description = "Controls whether a start/stop schedule will be created for the RDS instance (true) or not (false)"
+  default     = false
+}
+
+variable "rds_start_schedule" {
+  type        = string
+  description = "The SSM cron expression that defines when the RDS instance will be started"
+  default     = ""
+}
+
+variable "rds_stop_schedule" {
+  type        = string
+  description = "The SSM cron expression that defines when the RDS instance will be stopped"
+  default     = ""
+}
+
 # ------------------------------------------------------------------------------
 # RDS Engine Type Variables
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
Added module config for RDS start/stop
Added supporting variables for RDS start/stop schedules
Added schedules in Dev and Staging

Schedules are set such that the RDS will be stopped after the apps have stopped and started before the apps are started.