### PR TITLE
Increase Dev RDS storage to 30GiB

### DIFF
--- a/groups/xml-infrastructure/profiles/heritage-development-eu-west-2/vars
+++ b/groups/xml-infrastructure/profiles/heritage-development-eu-west-2/vars
@@ -54,7 +54,7 @@ nfs_mounts = {
 
 # RDS Instance settings
 instance_class          = "db.t3.medium"
-allocated_storage       = 20
+allocated_storage       = 30
 maximum_storage         = 40
 backup_retention_period = 2
 multi_az                = false


### PR DESCRIPTION
Increase `allocated_storage` to 30GiB for Dev RDS to accommodate for growth and upgrades.

NOTE: Not to be merged before Saturday 9th July