### PR TITLE
Add RDS CloudWatch Alarms

### DIFF
--- a/groups/xml-infrastructure/profiles/heritage-development-eu-west-2/vars
+++ b/groups/xml-infrastructure/profiles/heritage-development-eu-west-2/vars
@@ -321,3 +321,8 @@ bep_cw_logs = {
 rds_schedule_enable = true
 rds_start_schedule = "cron(0 5 * * ? *)"
 rds_stop_schedule = "cron(0 21 * * ? *)"
+
+## CloudWatch Alarms
+alarm_actions_enabled  = false
+alarm_topic_name       = ""
+alarm_topic_name_ooh   = ""

--- a/groups/xml-infrastructure/profiles/heritage-live-eu-west-2/vars
+++ b/groups/xml-infrastructure/profiles/heritage-live-eu-west-2/vars
@@ -326,3 +326,8 @@ bep_cw_logs = {
     log_group_retention = 180
   }
 }
+
+## CloudWatch Alarms
+alarm_actions_enabled  = false
+alarm_topic_name       = "Email_Alerts"
+alarm_topic_name_ooh   = "Phonecall_Alerts"

--- a/groups/xml-infrastructure/profiles/heritage-staging-eu-west-2/vars
+++ b/groups/xml-infrastructure/profiles/heritage-staging-eu-west-2/vars
@@ -341,3 +341,8 @@ bep_cw_logs = {
 rds_schedule_enable = true
 rds_start_schedule = "cron(0 5 * * ? *)"
 rds_stop_schedule = "cron(0 21 * * ? *)"
+
+## CloudWatch Alarms
+alarm_actions_enabled  = false
+alarm_topic_name       = ""
+alarm_topic_name_ooh   = ""

--- a/groups/xml-infrastructure/rds.tf
+++ b/groups/xml-infrastructure/rds.tf
@@ -151,3 +151,13 @@ module "rds_start_stop_schedule" {
   rds_start_schedule  = var.rds_start_schedule
   rds_stop_schedule   = var.rds_stop_schedule
 }
+
+module "rds_cloudwatch_alarms" {
+  source = "git@github.com:companieshouse/terraform-modules//aws/rds_cloudwatch_alarms?ref=tags/1.0.167"
+
+  rds_instance_id        = module.xml_rds.this_db_instance_id
+  rds_instance_shortname = upper(var.application)
+  alarm_actions_enabled  = var.alarm_actions_enabled
+  alarm_topic_name       = var.alarm_topic_name
+  alarm_topic_name_ooh   = var.alarm_topic_name_ooh
+}

--- a/groups/xml-infrastructure/variables.tf
+++ b/groups/xml-infrastructure/variables.tf
@@ -190,7 +190,7 @@ variable "rds_stop_schedule" {
 # RDS CloudWatch Alarm Variables
 # ------------------------------------------------------------------------------
 variable "alarm_actions_enabled" {
-  type        = string
+  type        = bool
   description = "Defines whether SNS-based alarm actions should be enabled (true) or not (false) for alarms"
 }
 

--- a/groups/xml-infrastructure/variables.tf
+++ b/groups/xml-infrastructure/variables.tf
@@ -187,6 +187,24 @@ variable "rds_stop_schedule" {
 }
 
 # ------------------------------------------------------------------------------
+# RDS CloudWatch Alarm Variables
+# ------------------------------------------------------------------------------
+variable "alarm_actions_enabled" {
+  type        = string
+  description = "Defines whether SNS-based alarm actions should be enabled (true) or not (false) for alarms"
+}
+
+variable "alarm_topic_name" {
+  type        = string
+  description = "The name of the SNS topic to use for in-hours alarm notifications and clear notifications"
+}
+
+variable "alarm_topic_name_ooh" {
+  type        = string
+  description = "The name of the SNS topic to use for OOH alarm notifications"
+}
+
+# ------------------------------------------------------------------------------
 # RDS Engine Type Variables
 # ------------------------------------------------------------------------------
 variable "major_engine_version" {


### PR DESCRIPTION
Added module and supporting config to deploy standard RDS CloudWatch alarms
alarm_actions currently disabled to prevent notification spam while alarms settle after creation