### PR TITLE
Allow access from test subnets in Live

### DIFF
--- a/groups/xml-infrastructure/alb-internal.tf
+++ b/groups/xml-infrastructure/alb-internal.tf
@@ -9,7 +9,7 @@ module "xml_internal_alb_security_group" {
   description = "Security group for the ${var.application} web servers"
   vpc_id      = data.aws_vpc.vpc.id
 
-  ingress_cidr_blocks = concat(local.admin_cidrs, local.websubnet_cidrs)
+  ingress_cidr_blocks = concat(local.admin_cidrs, local.websubnet_cidrs, local.test_cidrs)
   ingress_rules       = ["http-80-tcp", "https-443-tcp"]
   egress_rules        = ["all-all"]
 

--- a/groups/xml-infrastructure/data.tf
+++ b/groups/xml-infrastructure/data.tf
@@ -90,6 +90,10 @@ data "vault_generic_secret" "internal_cidrs" {
   path = "aws-accounts/network/internal_cidr_ranges"
 }
 
+data "vault_generic_secret" "test_cidrs" {
+  path = "aws-accounts/network/shared-services/test_cidr_ranges"
+}
+
 data "vault_generic_secret" "xml_rds_data" {
   path = "applications/${var.aws_profile}/${var.application}/rds"
 }

--- a/groups/xml-infrastructure/locals.tf
+++ b/groups/xml-infrastructure/locals.tf
@@ -3,6 +3,7 @@
 # ------------------------------------------------------------------------
 locals {
   admin_cidrs  = values(data.vault_generic_secret.internal_cidrs.data)
+  test_cidrs   = var.test_access_enable ? jsondecode(data.vault_generic_secret.test_cidrs.data["cidrs"]) : []
   s3_releases  = data.vault_generic_secret.s3_releases.data
   xml_ec2_data = data.vault_generic_secret.xml_ec2_data.data
   xml_rds_data = data.vault_generic_secret.xml_rds_data.data

--- a/groups/xml-infrastructure/profiles/heritage-live-eu-west-2/vars
+++ b/groups/xml-infrastructure/profiles/heritage-live-eu-west-2/vars
@@ -333,3 +333,5 @@ alarm_topic_name       = "Email_Alerts"
 alarm_topic_name_ooh   = "Phonecall_Alerts"
 
 ef_presenter_data_import = true
+
+test_access_enable = true

--- a/groups/xml-infrastructure/variables.tf
+++ b/groups/xml-infrastructure/variables.tf
@@ -290,6 +290,12 @@ variable "public_allow_cidr_blocks" {
   description = "cidr block list for allowing inbound users from internet"
 }
 
+variable "test_access_enable" {
+  type        = bool
+  description = "Controls whether access from the Test subnets is required (true) or not (false)"
+  default     = false
+}
+
 # ------------------------------------------------------------------------------
 # XML Backend Variables
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
Added support to optionally allow access from test subnets via internal ALB
Added local to conditionally construct the list of CIDRs
Updated internal ALB SG to include the CIDRs
Enabled access for Live

Resolves: INC0365535
