### PR TITLE
Per-profile RDS options, disable JVM in staging

### DIFF
--- a/groups/xml-infrastructure/profiles/heritage-development-eu-west-2/vars
+++ b/groups/xml-infrastructure/profiles/heritage-development-eu-west-2/vars
@@ -164,6 +164,31 @@ parameter_group_settings = [
     },
 ]
 
+option_group_settings = [
+  {
+    option_name = "JVM"
+  },
+  {
+    option_name = "SQLT"
+    version     = "2018-07-25.v1"
+    option_settings = [
+      {
+        name  = "LICENSE_PACK"
+        value = "N"
+      },
+    ]
+  },
+  {
+    option_name = "Timezone"
+    option_settings = [
+      {
+        name  = "TIME_ZONE"
+        value = "Europe/London"
+      },
+    ]
+  }
+]
+
 fe_cw_logs = {
   "audit.log" = {
     file_path = "/var/log/audit"

--- a/groups/xml-infrastructure/profiles/heritage-live-eu-west-2/vars
+++ b/groups/xml-infrastructure/profiles/heritage-live-eu-west-2/vars
@@ -173,6 +173,31 @@ parameter_group_settings = [
     },
 ]
 
+option_group_settings = [
+  {
+    option_name = "JVM"
+  },
+  {
+    option_name = "SQLT"
+    version     = "2018-07-25.v1"
+    option_settings = [
+      {
+        name  = "LICENSE_PACK"
+        value = "N"
+      },
+    ]
+  },
+  {
+    option_name = "Timezone"
+    option_settings = [
+      {
+        name  = "TIME_ZONE"
+        value = "Europe/London"
+      },
+    ]
+  }
+]
+
 fe_cw_logs = {
   "audit.log" = {
     file_path = "/var/log/audit"

--- a/groups/xml-infrastructure/profiles/heritage-staging-eu-west-2/vars
+++ b/groups/xml-infrastructure/profiles/heritage-staging-eu-west-2/vars
@@ -86,7 +86,7 @@ rds_backup_window       = "03:00-06:00"
 major_engine_version        = "19"
 engine_version              = "19"
 license_model               = "license-included"
-auto_minor_version_upgrade  = true
+auto_minor_version_upgrade  = false
 
 # RDS Access
 rds_onpremise_access = [
@@ -182,6 +182,28 @@ parameter_group_settings = [
       name  = "workarea_size_policy"
       value = "AUTO"
     },
+]
+
+option_group_settings = [
+  {
+    option_name = "SQLT"
+    version     = "2018-07-25.v1"
+    option_settings = [
+      {
+        name  = "LICENSE_PACK"
+        value = "N"
+      },
+    ]
+  },
+  {
+    option_name = "Timezone"
+    option_settings = [
+      {
+        name  = "TIME_ZONE"
+        value = "Europe/London"
+      },
+    ]
+  }
 ]
 
 fe_cw_logs = {

--- a/groups/xml-infrastructure/rds.tf
+++ b/groups/xml-infrastructure/rds.tf
@@ -98,35 +98,13 @@ module "xml_rds" {
 
   parameters = var.parameter_group_settings
 
-  options = [
+  options = concat([
     {
       option_name                    = "OEM"
       port                           = "5500"
       vpc_security_group_memberships = [module.xml_rds_security_group.this_security_group_id]
-    },
-    {
-      option_name = "JVM"
-    },
-    {
-      option_name = "SQLT"
-      version     = "2018-07-25.v1"
-      option_settings = [
-        {
-          name  = "LICENSE_PACK"
-          value = "N"
-        },
-      ]
-    },
-    {
-      option_name = "Timezone"
-      option_settings = [
-        {
-          name  = "TIME_ZONE"
-          value = "Europe/London"
-        },
-      ]
     }
-  ]
+  ], var.option_group_settings)
 
   timeouts = {
     "create" : "80m",

--- a/groups/xml-infrastructure/variables.tf
+++ b/groups/xml-infrastructure/variables.tf
@@ -140,6 +140,11 @@ variable "parameter_group_settings" {
   description = "A list of parameters that will be set in the RDS instance parameter group"
 }
 
+variable "option_group_settings" {
+  type        = any
+  description = "A list of options that will be set in the RDS instance option group"
+}
+
 variable "rds_onpremise_access" {
   type        = list(any)
   description = "A list of cidr ranges that will be allowed access to RDS"


### PR DESCRIPTION
Moved RDS options in to vars to allow for per-profile changes
Updated rds.tf to concatenate standard OEM option with profile options
Removed JVM option and disabeld minor version upgrades in Staging