### PR TITLE
Use parameter store instead of embedding secrets in user data

### DIFF
--- a/groups/xml-infrastructure/data.tf
+++ b/groups/xml-infrastructure/data.tf
@@ -170,10 +170,10 @@ data "template_file" "fe_userdata" {
   template = file("${path.module}/templates/fe_user_data.tpl")
 
   vars = {
-    REGION               = var.aws_region
-    HERITAGE_ENVIRONMENT = title(var.environment)
-    XML_FRONTEND_INPUTS  = local.xml_fe_data
-    ANSIBLE_INPUTS       = jsonencode(local.xml_fe_ansible_inputs)
+    REGION                   = var.aws_region
+    HERITAGE_ENVIRONMENT     = title(var.environment)
+    XML_FRONTEND_INPUTS_PATH = "${local.parameter_store_path_prefix}/frontend_inputs"
+    ANSIBLE_INPUTS_PATH      = "${local.parameter_store_path_prefix}/frontend_ansible_inputs"
   }
 }
 
@@ -209,20 +209,21 @@ data "aws_ami" "bep_xml" {
   }
 }
 
+data "template_file" "xml_cron_file" {
+  template = file("${path.module}/templates/${var.aws_profile}/bep_cron.tpl")
+  vars     = local.xml_cron_variables
+}
+
 data "template_file" "bep_userdata" {
   template = file("${path.module}/templates/bep_user_data.tpl")
 
   vars = {
-    REGION               = var.aws_region
-    HERITAGE_ENVIRONMENT = title(var.environment)
-    XML_BACKEND_INPUTS   = local.xml_bep_data
-    ANSIBLE_INPUTS       = jsonencode(local.xml_bep_ansible_inputs)
-    XML_CRON_ENTRIES = templatefile(
-      "${path.module}/templates/${var.aws_profile}/bep_cron.tpl",
-      local.xml_cron_variables
-    )
-
-    XML_FESS_TOKEN = data.vault_generic_secret.xml_fess_data.data["fess_token"]
+    REGION                  = var.aws_region
+    HERITAGE_ENVIRONMENT    = title(var.environment)
+    XML_BACKEND_INPUTS_PATH = "${local.parameter_store_path_prefix}/backend_inputs"
+    ANSIBLE_INPUTS_PATH     = "${local.parameter_store_path_prefix}/backend_ansible_inputs"
+    XML_CRON_ENTRIES_PATH   = "${local.parameter_store_path_prefix}/backend_cron_entries"
+    XML_FESS_TOKEN_PATH     = "${local.parameter_store_path_prefix}/backend_fess_token"
   }
 }
 

--- a/groups/xml-infrastructure/iam.tf
+++ b/groups/xml-infrastructure/iam.tf
@@ -3,24 +3,18 @@ module "xml_fe_profile" {
 
   name       = "xml-frontend-profile"
   enable_SSM = true
-  cw_log_group_arns = length(local.fe_log_groups) > 0 ? flatten([
-    formatlist(
-      "arn:aws:logs:%s:%s:log-group:%s:*:*",
-      var.aws_region,
-      data.aws_caller_identity.current.account_id,
-      local.fe_log_groups
-    ),
-    formatlist("arn:aws:logs:%s:%s:log-group:%s:*",
-      var.aws_region,
-      data.aws_caller_identity.current.account_id,
-      local.fe_log_groups
-    ),
-  ]) : null
+  cw_log_group_arns = length(local.fe_log_groups) > 0 ? [format(
+    "arn:aws:logs:%s:%s:log-group:%s-fe-*:*",
+    var.aws_region,
+    data.aws_caller_identity.current.account_id,
+    var.application
+  )] : null
   s3_buckets_write  = [local.session_manager_bucket_name]
   instance_asg_arns = [module.fe_asg.this_autoscaling_group_arn]
   kms_key_refs = [
     "alias/${var.account}/${var.region}/ebs",
-    local.ssm_kms_key_id
+    local.ssm_kms_key_id,
+    local.account_ssm_key_arn
   ]
   custom_statements = [
     {
@@ -36,6 +30,14 @@ module "xml_fe_profile" {
         "s3:Get*",
         "s3:List*",
       ]
+    },
+    {
+      sid       = "AllowReadOfParameterStore",
+      effect    = "Allow",
+      resources = ["arn:aws:ssm:${var.aws_region}:${data.aws_caller_identity.current.account_id}:parameter/${var.application}/${var.environment}/*"],
+      actions = [
+        "ssm:GetParameter*"
+      ]
     }
   ]
 }
@@ -45,24 +47,18 @@ module "xml_bep_profile" {
 
   name       = "xml-backend-profile"
   enable_SSM = true
-  cw_log_group_arns = length(local.bep_log_groups) > 0 ? flatten([
-    formatlist(
-      "arn:aws:logs:%s:%s:log-group:%s:*:*",
-      var.aws_region,
-      data.aws_caller_identity.current.account_id,
-      local.bep_log_groups
-    ),
-    formatlist("arn:aws:logs:%s:%s:log-group:%s:*",
-      var.aws_region,
-      data.aws_caller_identity.current.account_id,
-      local.bep_log_groups
-    ),
-  ]) : null
+  cw_log_group_arns = length(local.bep_log_groups) > 0 ? [format(
+    "arn:aws:logs:%s:%s:log-group:%s-bep-*:*",
+    var.aws_region,
+    data.aws_caller_identity.current.account_id,
+    var.application
+  )] : null
   s3_buckets_write  = [local.session_manager_bucket_name]
   instance_asg_arns = [module.bep_asg.this_autoscaling_group_arn]
   kms_key_refs = [
     "alias/${var.account}/${var.region}/ebs",
-    local.ssm_kms_key_id
+    local.ssm_kms_key_id,
+    local.account_ssm_key_arn
   ]
   custom_statements = [
     {
@@ -77,6 +73,14 @@ module "xml_bep_profile" {
       actions = [
         "s3:Get*",
         "s3:List*",
+      ]
+    },
+    {
+      sid       = "AllowReadOfParameterStore",
+      effect    = "Allow",
+      resources = ["arn:aws:ssm:${var.aws_region}:${data.aws_caller_identity.current.account_id}:parameter/${var.application}/${var.environment}/*"],
+      actions = [
+        "ssm:GetParameter*"
       ]
     }
   ]

--- a/groups/xml-infrastructure/locals.tf
+++ b/groups/xml-infrastructure/locals.tf
@@ -13,6 +13,7 @@ locals {
 
   kms_keys_data          = data.vault_generic_secret.kms_keys.data
   security_kms_keys_data = data.vault_generic_secret.security_kms_keys.data
+  account_ssm_key_arn    = local.kms_keys_data["ssm"]
   logs_kms_key_id        = local.kms_keys_data["logs"]
   sns_kms_key_id         = local.kms_keys_data["sns"]
   ssm_kms_key_id         = local.security_kms_keys_data["session-manager-kms-key-arn"]
@@ -89,4 +90,15 @@ locals {
     "PASSWORD" = data.vault_generic_secret.xml_bep_cron_data.data["password"]
   },
   local.ef_presenter_data_import_variables)
+
+  parameter_store_path_prefix = "/${var.application}/${var.environment}"
+
+  parameter_store_secrets = {
+    frontend_inputs         = local.xml_fe_data
+    frontend_ansible_inputs = jsonencode(local.xml_fe_ansible_inputs)
+    backend_inputs          = local.xml_bep_data
+    backend_ansible_inputs  = jsonencode(local.xml_bep_ansible_inputs)
+    backend_cron_entries    = data.template_file.xml_cron_file.rendered
+    backend_fess_token      = data.vault_generic_secret.xml_fess_data.data["fess_token"]
+  }
 }

--- a/groups/xml-infrastructure/parameter-store.tf
+++ b/groups/xml-infrastructure/parameter-store.tf
@@ -1,0 +1,13 @@
+resource "aws_ssm_parameter" "parameters" {
+  for_each = local.parameter_store_secrets
+
+  name   = "${local.parameter_store_path_prefix}/${each.key}"
+  type   = "SecureString"
+  value  = each.value
+  key_id = local.account_ssm_key_arn
+
+  tags = {
+    Environment = var.environment
+    Application = var.application
+  }
+}

--- a/groups/xml-infrastructure/templates/bep_user_data.tpl
+++ b/groups/xml-infrastructure/templates/bep_user_data.tpl
@@ -2,17 +2,16 @@
 # Redirect the user-data output to the console logs
 exec > >(tee /var/log/user-data.log|logger -t user-data -s 2>/dev/console) 2>&1
 
+GET_PARAM_COMMAND="/usr/local/bin/aws ssm get-parameter --with-decryption --region ${REGION} --output text --query Parameter.Value --name"
+
 #Create key:value variable
-cat <<EOF >>inputs.json
-${XML_BACKEND_INPUTS}
-EOF
+$${GET_PARAM_COMMAND} '${XML_BACKEND_INPUTS_PATH}' > inputs.json
 #Create cron file and set crontab for EWF user:
-cat <<EOF >>/root/cronfile
-${XML_CRON_ENTRIES}
-EOF
+$${GET_PARAM_COMMAND} '${XML_CRON_ENTRIES_PATH}' > /root/cronfile
 crontab -u xml /root/cronfile
 #Set FESS_TOKEN
-echo "export FESS_TOKEN=${XML_FESS_TOKEN}" >> /home/xml/.bash_profile
+FESS_TOKEN=$($${GET_PARAM_COMMAND} '${XML_FESS_TOKEN_PATH}')
+echo "export FESS_TOKEN=$${FESS_TOKEN}" >> /home/xml/.bash_profile
 #Update Nagios registration script with relevant template
 cp /usr/local/bin/nagios-host-add.sh /usr/local/bin/nagios-host-add.j2
 REPLACE=XML_BEP_${HERITAGE_ENVIRONMENT} /usr/local/bin/j2 /usr/local/bin/nagios-host-add.j2 > /usr/local/bin/nagios-host-add.sh
@@ -23,7 +22,8 @@ rm /etc/httpd/conf.d/welcome.conf
 rm /etc/httpd/conf.d/ssl.conf
 rm /etc/httpd/conf.d/perl.conf
 #Run Ansible playbook for Backend deployment using provided inputs
-/usr/local/bin/ansible-playbook /root/backend_deployment.yml -e '${ANSIBLE_INPUTS}'
+$${GET_PARAM_COMMAND} '${ANSIBLE_INPUTS_PATH}' > /root/ansible_inputs.json
+/usr/local/bin/ansible-playbook /root/backend_deployment.yml -e '@/root/ansible_inputs.json'
 # Update hostname and reboot
 INSTANCEID=$(curl http://169.254.169.254/latest/meta-data/instance-id)
 sed -i "s/HOSTNAME=.*/HOSTNAME=$INSTANCEID/" /etc/sysconfig/network

--- a/groups/xml-infrastructure/templates/fe_user_data.tpl
+++ b/groups/xml-infrastructure/templates/fe_user_data.tpl
@@ -2,10 +2,10 @@
 # Redirect the user-data output to the console logs
 exec > >(tee /var/log/user-data.log|logger -t user-data -s 2>/dev/console) 2>&1
 
+GET_PARAM_COMMAND="/usr/local/bin/aws ssm get-parameter --with-decryption --region ${REGION} --output text --query Parameter.Value --name"
+
 #Create key:value variable
-cat <<EOF >>inputs.json
-${XML_FRONTEND_INPUTS}
-EOF
+$${GET_PARAM_COMMAND} '${XML_FRONTEND_INPUTS_PATH}' > inputs.json
 #Update Nagios registration script with relevant template
 cp /usr/local/bin/nagios-host-add.sh /usr/local/bin/nagios-host-add.j2
 REPLACE=XML_Web_${HERITAGE_ENVIRONMENT} /usr/local/bin/j2 /usr/local/bin/nagios-host-add.j2 > /usr/local/bin/nagios-host-add.sh
@@ -20,4 +20,5 @@ rm /etc/httpd/conf.d/perl.conf
 #Create and populate the perl config
 /usr/local/bin/j2 -f json /etc/httpd/conf.d/perl.conf.j2 inputs.json > /etc/httpd/conf.d/perl.conf
 #Run Ansible playbook for Frontend deployment using provided inputs
-/usr/local/bin/ansible-playbook /root/frontend_deployment.yml -e '${ANSIBLE_INPUTS}'
+$${GET_PARAM_COMMAND} '${ANSIBLE_INPUTS_PATH}' > /root/ansible_inputs.json
+/usr/local/bin/ansible-playbook /root/frontend_deployment.yml -e '@/root/ansible_inputs.json'


### PR DESCRIPTION
Avoid embedding any sensitive data in the user data scripts for xml-bep or xml-frontend, and instead add the data to parameter store and then read it as the scripts run.

Also optimises the IAM policy for logging to avoid going over the size limit for an inline policy.

Resolves:
https://companieshouse.atlassian.net/browse/DVOP-2677