### PR TITLE
Force instance recreation on change of app version

### DIFF
--- a/groups/xml-infrastructure/data.tf
+++ b/groups/xml-infrastructure/data.tf
@@ -172,6 +172,7 @@ data "template_file" "fe_userdata" {
   vars = {
     REGION                   = var.aws_region
     HERITAGE_ENVIRONMENT     = title(var.environment)
+    APP_VERSION              = var.fe_app_release_version
     XML_FRONTEND_INPUTS_PATH = "${local.parameter_store_path_prefix}/frontend_inputs"
     ANSIBLE_INPUTS_PATH      = "${local.parameter_store_path_prefix}/frontend_ansible_inputs"
   }
@@ -220,6 +221,7 @@ data "template_file" "bep_userdata" {
   vars = {
     REGION                  = var.aws_region
     HERITAGE_ENVIRONMENT    = title(var.environment)
+    APP_VERSION             = var.bep_app_release_version
     XML_BACKEND_INPUTS_PATH = "${local.parameter_store_path_prefix}/backend_inputs"
     ANSIBLE_INPUTS_PATH     = "${local.parameter_store_path_prefix}/backend_ansible_inputs"
     XML_CRON_ENTRIES_PATH   = "${local.parameter_store_path_prefix}/backend_cron_entries"

--- a/groups/xml-infrastructure/templates/bep_user_data.tpl
+++ b/groups/xml-infrastructure/templates/bep_user_data.tpl
@@ -23,6 +23,7 @@ rm /etc/httpd/conf.d/ssl.conf
 rm /etc/httpd/conf.d/perl.conf
 #Run Ansible playbook for Backend deployment using provided inputs
 $${GET_PARAM_COMMAND} '${ANSIBLE_INPUTS_PATH}' > /root/ansible_inputs.json
+echo "Deploying ${APP_VERSION}"
 /usr/local/bin/ansible-playbook /root/backend_deployment.yml -e '@/root/ansible_inputs.json'
 # Update hostname and reboot
 INSTANCEID=$(curl http://169.254.169.254/latest/meta-data/instance-id)

--- a/groups/xml-infrastructure/templates/fe_user_data.tpl
+++ b/groups/xml-infrastructure/templates/fe_user_data.tpl
@@ -21,4 +21,5 @@ rm /etc/httpd/conf.d/perl.conf
 /usr/local/bin/j2 -f json /etc/httpd/conf.d/perl.conf.j2 inputs.json > /etc/httpd/conf.d/perl.conf
 #Run Ansible playbook for Frontend deployment using provided inputs
 $${GET_PARAM_COMMAND} '${ANSIBLE_INPUTS_PATH}' > /root/ansible_inputs.json
+echo "Deploying ${APP_VERSION}"
 /usr/local/bin/ansible-playbook /root/frontend_deployment.yml -e '@/root/ansible_inputs.json'


### PR DESCRIPTION
Include the app version in the user data to trigger the EC2 instance to be recreated when it changes. Without this, the instances would have to be manually terminated/recreated to pick up a change of application version.

Resolves:
https://companieshouse.atlassian.net/browse/DVOP-2677