### PR TITLE
Enable cloud access to the xmlgw database

### DIFF
--- a/groups/xml-infrastructure/profiles/heritage-development-eu-west-2/vars
+++ b/groups/xml-infrastructure/profiles/heritage-development-eu-west-2/vars
@@ -68,6 +68,12 @@ license_model               = "license-included"
 auto_minor_version_upgrade  = true
 
 # RDS Access
+rds_cloud_access = {
+  mesos_euw2a = "10.75.40.0/21",
+  mesos_euw2b = "10.75.80.0/21",
+  mesos_euw2c = "10.75.120.0/21"
+}
+
 rds_onpremise_access = [
   "192.168.90.0/24"
 ]

--- a/groups/xml-infrastructure/rds.tf
+++ b/groups/xml-infrastructure/rds.tf
@@ -40,6 +40,18 @@ module "xml_rds_security_group" {
   egress_rules = ["all-all"]
 }
 
+resource "aws_security_group_rule" "rds_cloud_ingress" {
+  for_each = var.rds_cloud_access
+
+  description       = "Ingress access from ${each.key}"
+  type              = "ingress"
+  from_port         = 1521
+  to_port           = 1521
+  protocol          = "tcp"
+  cidr_blocks       = [each.value]
+  security_group_id = module.xml_rds_security_group.this_security_group_id
+}
+
 resource "aws_security_group_rule" "dba_dev_ingress" {
   for_each = toset(local.dba_dev_cidrs_list)
 

--- a/groups/xml-infrastructure/variables.tf
+++ b/groups/xml-infrastructure/variables.tf
@@ -145,6 +145,12 @@ variable "option_group_settings" {
   description = "A list of options that will be set in the RDS instance option group"
 }
 
+variable "rds_cloud_access" {
+  type        = map(any)
+  description = "A map of CIDR blocks names and values from Cloud sources that will be allowed access to RDS"
+  default     = {}
+}
+
 variable "rds_onpremise_access" {
   type        = list(any)
   description = "A list of cidr ranges that will be allowed access to RDS"


### PR DESCRIPTION
This pr adds access to the xmlgw database to cloud sources in mesos. This is so the presenter account consumer can save new presenter accounts in xmlgw.

Jira:
[AOAF-296](https://companieshouse.atlassian.net/browse/AOAF-296)

[AOAF-296]: https://companieshouse.atlassian.net/browse/AOAF-296?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ