### PR TITLE
disable tenable cwp scan

### DIFF
--- a/groups/xml-infrastructure/asg-backend.tf
+++ b/groups/xml-infrastructure/asg-backend.tf
@@ -96,7 +96,9 @@ module "bep_asg" {
   tags_as_map = merge(
     local.default_tags,
     {
-      ServiceTeam = "${upper(var.application)}-FE-Support"
+      ServiceTeam               = "${upper(var.application)}-FE-Support"
+      tenable-cwp-scan-disabled = "true"
+      Repository                = "xml-terraform"
     }
   )
 }

--- a/groups/xml-infrastructure/asg-frontend.tf
+++ b/groups/xml-infrastructure/asg-frontend.tf
@@ -109,7 +109,9 @@ module "fe_asg" {
   tags_as_map = merge(
     local.default_tags,
     {
-      ServiceTeam = "${upper(var.application)}-FE-Support"
+      ServiceTeam               = "${upper(var.application)}-FE-Support"
+      tenable-cwp-scan-disabled = "true"
+      Repository                = "xml-terraform"
     }
   )
   depends_on = [


### PR DESCRIPTION
This is for [DVOP-4517](https://companieshouse.atlassian.net/browse/DVOP-4517)

There is an issue where workload scanning cannot run on certain instances either due to licensing restrictions or the workload doesn't support the scanner.

Once they have been excluded, inspector will be ingested into tenable ([DVOP-4853](https://companieshouse.atlassian.net/browse/DVOP-4853)) instead to restore the data and circumvent the workload scanning issues

[DVOP-4517]: https://companieshouse.atlassian.net/browse/DVOP-4517?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DVOP-4853]: https://companieshouse.atlassian.net/browse/DVOP-4853?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ